### PR TITLE
Replace model name with base model prefix

### DIFF
--- a/test/test_explainer.py
+++ b/test/test_explainer.py
@@ -45,7 +45,7 @@ def test_explainer_init():
     assert isinstance(explainer.tokenizer, PreTrainedTokenizerFast) | isinstance(
         explainer.tokenizer, PreTrainedTokenizer
     )
-    assert explainer.model_type == MODEL.config.model_type
+    assert explainer.model_prefix == MODEL.base_model_prefix
     if torch.cuda.is_available():
         assert explainer.device.type == "cuda:0"
     else:

--- a/transformers_interpret/explainer.py
+++ b/transformers_interpret/explainer.py
@@ -20,7 +20,7 @@ class BaseExplainer(ABC):
         self.sep_token_id = self.tokenizer.sep_token_id
         self.cls_token_id = self.tokenizer.cls_token_id
 
-        self.model_type = model.config.model_type
+        self.model_prefix = model.base_model_prefix
 
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model.to(self.device)

--- a/transformers_interpret/explainers/sequence_classification.py
+++ b/transformers_interpret/explainers/sequence_classification.py
@@ -81,7 +81,7 @@ class SequenceClassificationExplainer(BaseExplainer):
             return self.predicted_class_index
 
     def visualize(self, html_filepath: str = None, true_class: str = None):
-        tokens = self.tokenizer.convert_ids_to_tokens(self.input_ids[0])
+        tokens = [token.replace("Ġ","") for token in self.decode(self.input_ids)]
         attr_class = self.id2label[int(self.selected_index)]
         if true_class is None:
             true_class = self.predicted_class_name
@@ -120,10 +120,11 @@ class SequenceClassificationExplainer(BaseExplainer):
                 self.selected_index = self.predicted_class_index
         else:
             self.selected_index = self.predicted_class_index
-
         if self.attribution_type == "lig":
-            embeddings = getattr(self.model, self.model_type).embeddings
-            reference_tokens = self.decode(self.input_ids)
+            embeddings = getattr(self.model, self.model_prefix).embeddings
+            # embeddings = self.model.get_input_embeddings()
+            # embeddings = getattr(self.model, self.model_prefix).get_input_embeddings()
+            reference_tokens = [token.replace("Ġ","") for token in self.decode(self.input_ids)]
             lig = LIGAttributions(
                 self._forward,
                 embeddings,


### PR DESCRIPTION
- No longer using `model_type` as attribute for accessing embeddings as `mode.base_model_prefix` is more consistent across all models for accessing modules, embeddings, and additional layers. 
- This will make a  likely future switch ( #14 ) to using word embeddings only for LayerIntegratedGradients much more streamlined. This decision is still TBD but seems likely.