### PR TITLE
Embeddings defaults to model.get_input_embeddings() for all models

### DIFF
--- a/transformers_interpret/explainers/sequence_classification.py
+++ b/transformers_interpret/explainers/sequence_classification.py
@@ -57,12 +57,13 @@ class SequenceClassificationExplainer(BaseExplainer):
 
     def _forward(self, input_ids):
         preds = self.model(input_ids)[0]
-        self.pred_probs = torch.softmax(preds, dim=1)[0][1]
+        self.pred_probs = torch.softmax(preds, dim=1)[0][self.selected_index]
         return torch.softmax(preds, dim=1)[0][self.selected_index].unsqueeze(-1)
 
     @property
     def predicted_class_index(self):
         if self.input_ids is not None:
+            # we call this before _forward() so it has to be calculated twice
             preds = self.model(self.input_ids)[0]
             self.pred_class = torch.argmax(torch.softmax(preds, dim=0)[0])
             return torch.argmax(torch.softmax(preds, dim=1)[0]).cpu().detach().numpy()
@@ -121,9 +122,7 @@ class SequenceClassificationExplainer(BaseExplainer):
         else:
             self.selected_index = self.predicted_class_index
         if self.attribution_type == "lig":
-            embeddings = getattr(self.model, self.model_prefix).embeddings
-            # embeddings = self.model.get_input_embeddings()
-            # embeddings = getattr(self.model, self.model_prefix).get_input_embeddings()
+            embeddings = self.model.get_input_embeddings()
             reference_tokens = [token.replace("Ġ","") for token in self.decode(self.input_ids)]
             lig = LIGAttributions(
                 self._forward,


### PR DESCRIPTION
- This is a small change but adds compatibility for most if not all models in the HF library when fetching embeddings
- This change is opinionated and now only selects input embeddings (word embeddings) as the embeddings from which it calculates attributions along. 
- I'm still researching this a bit to sanity check this as a choice, there are subtle but real differences between the attributions when using input embeddings versus Bert like models `model.bert.embeddings` which is usually a collection of embedding layers. 
- I'll convert this to a regular PR when I feel a bit more sure of the decision.   