### PR TITLE
Feature/refactor base constructor (#26) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,9 @@ tokenizer = AutoTokenizer.from_pretrained(model_name)
 
 from transformers_interpret import SequenceClassificationExplainer
 cls_explainer = SequenceClassificationExplainer(
-    "I love you, I like you", 
     model, 
     tokenizer)
-attributions = cls_explainer()
+attributions = cls_explainer("I love you, I like you")
 ```
 
 Which will return the following list of tuples:
@@ -118,8 +117,8 @@ Attribution explanations are not limited to the predicted class. Let's test a mo
 In the example below we pass `class_name="NEGATIVE"` as an argument indicating we would like the attributions to be explained for the **NEGATIVE** class regardless of what the actual prediction is. Effectively because this is a binary classifier we are getting the inverse attributions.
 
 ```python
-cls_explainer = SequenceClassificationExplainer("I love you, I like you, I also kinda dislike you", model, tokenizer)
-attributions = cls_explainer(class_name="NEGATIVE")
+cls_explainer = SequenceClassificationExplainer(model, tokenizer)
+attributions = cls_explainer("I love you, I like you, I also kinda dislike you", class_name="NEGATIVE")
 ```
 
 In this case, `predicted_class_name` still returns a prediction of the **POSITIVE** class, because the model has generated the same prediction but nonetheless we are interested in looking at the attributions for the negative class regardless of the predicted result. 

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ from transformers_interpret import SequenceClassificationExplainer
 cls_explainer = SequenceClassificationExplainer(
     model, 
     tokenizer)
-attributions = cls_explainer("I love you, I like you")
+word_attributions = cls_explainer("I love you, I like you")
 ```
 
 Which will return the following list of tuples:
 
 ```python
->>> attributions.word_attributions
+>>> word_attributions
 [('[CLS]', 0.0),
  ('i', 0.2778544699186709),
  ('love', 0.7792370723380415),

--- a/test/test_explainer.py
+++ b/test/test_explainer.py
@@ -34,6 +34,10 @@ class DummyExplainer(BaseExplainer):
     def decode(self, input_ids):
         return self.tokenizer.convert_ids_to_tokens(input_ids[0])
 
+    @property
+    def word_attributions(self):
+        pass
+
     def _run(self):
         pass
 

--- a/test/test_explainer.py
+++ b/test/test_explainer.py
@@ -29,8 +29,6 @@ class DummyExplainer(BaseExplainer):
         super().__init__(*args, **kwargs)
 
     def encode(self, text: str = None):
-        if text is None:
-            text = self.text
         return self.tokenizer.encode(text, add_special_tokens=False)
 
     def decode(self, input_ids):
@@ -47,8 +45,7 @@ class DummyExplainer(BaseExplainer):
 
 
 def test_explainer_init_distilbert():
-    explainer = DummyExplainer("testing", DISTILBERT_MODEL, DISTILBERT_TOKENIZER)
-    assert explainer.text == "testing"
+    explainer = DummyExplainer(DISTILBERT_MODEL, DISTILBERT_TOKENIZER)
     assert isinstance(explainer.model, PreTrainedModel)
     assert isinstance(explainer.tokenizer, PreTrainedTokenizerFast) | isinstance(
         explainer.tokenizer, PreTrainedTokenizer
@@ -69,8 +66,7 @@ def test_explainer_init_distilbert():
 
 
 def test_explainer_init_bert():
-    explainer = DummyExplainer("testing", BERT_MODEL, BERT_TOKENIZER)
-    assert explainer.text == "testing"
+    explainer = DummyExplainer(BERT_MODEL, BERT_TOKENIZER)
     assert isinstance(explainer.model, PreTrainedModel)
     assert isinstance(explainer.tokenizer, PreTrainedTokenizerFast) | isinstance(
         explainer.tokenizer, PreTrainedTokenizer
@@ -91,8 +87,7 @@ def test_explainer_init_bert():
 
 
 def test_explainer_init_gpt2():
-    explainer = DummyExplainer("testing", GPT2_MODEL, GPT2_TOKENIZER)
-    assert explainer.text == "testing"
+    explainer = DummyExplainer(GPT2_MODEL, GPT2_TOKENIZER)
     assert isinstance(explainer.model, PreTrainedModel)
     assert isinstance(explainer.tokenizer, PreTrainedTokenizerFast) | isinstance(
         explainer.tokenizer, PreTrainedTokenizer
@@ -112,9 +107,7 @@ def test_explainer_init_gpt2():
 
 
 def test_explainer_make_input_reference_pair():
-    explainer = DummyExplainer(
-        "this is a test string", DISTILBERT_MODEL, DISTILBERT_TOKENIZER
-    )
+    explainer = DummyExplainer(DISTILBERT_MODEL, DISTILBERT_TOKENIZER)
     input_ids, ref_input_ids, len_inputs = explainer._make_input_reference_pair(
         "this is a test string"
     )
@@ -130,7 +123,7 @@ def test_explainer_make_input_reference_pair():
 
 
 def test_explainer_make_input_reference_pair_gpt2():
-    explainer = DummyExplainer("this is a test string", GPT2_MODEL, GPT2_TOKENIZER)
+    explainer = DummyExplainer(GPT2_MODEL, GPT2_TOKENIZER)
     input_ids, ref_input_ids, len_inputs = explainer._make_input_reference_pair(
         "this is a test string"
     )
@@ -142,9 +135,7 @@ def test_explainer_make_input_reference_pair_gpt2():
 
 
 def test_explainer_make_input_token_type_pair_no_sep_idx():
-    explainer = DummyExplainer(
-        "this is a test string", DISTILBERT_MODEL, DISTILBERT_TOKENIZER
-    )
+    explainer = DummyExplainer(DISTILBERT_MODEL, DISTILBERT_TOKENIZER)
     input_ids, ref_input_ids, len_inputs = explainer._make_input_reference_pair(
         "this is a test string"
     )
@@ -162,9 +153,7 @@ def test_explainer_make_input_token_type_pair_no_sep_idx():
 
 
 def test_explainer_make_input_token_type_pair_sep_idx():
-    explainer = DummyExplainer(
-        "this is a test string", DISTILBERT_MODEL, DISTILBERT_TOKENIZER
-    )
+    explainer = DummyExplainer(DISTILBERT_MODEL, DISTILBERT_TOKENIZER)
     input_ids, ref_input_ids, len_inputs = explainer._make_input_reference_pair(
         "this is a test string"
     )
@@ -182,9 +171,7 @@ def test_explainer_make_input_token_type_pair_sep_idx():
 
 
 def test_explainer_make_input_reference_position_id_pair():
-    explainer = DummyExplainer(
-        "this is a test string", DISTILBERT_MODEL, DISTILBERT_TOKENIZER
-    )
+    explainer = DummyExplainer(DISTILBERT_MODEL, DISTILBERT_TOKENIZER)
     input_ids, ref_input_ids, len_inputs = explainer._make_input_reference_pair(
         "this is a test string"
     )
@@ -198,9 +185,7 @@ def test_explainer_make_input_reference_position_id_pair():
 
 
 def test_explainer_make_attention_mask():
-    explainer = DummyExplainer(
-        "this is a test string", DISTILBERT_MODEL, DISTILBERT_TOKENIZER
-    )
+    explainer = DummyExplainer(DISTILBERT_MODEL, DISTILBERT_TOKENIZER)
     input_ids, ref_input_ids, len_inputs = explainer._make_input_reference_pair(
         "this is a test string"
     )
@@ -211,10 +196,8 @@ def test_explainer_make_attention_mask():
 
 
 def test_explainer_str():
-    test_string = "this is a test string"
-    explainer = DummyExplainer(test_string, DISTILBERT_MODEL, DISTILBERT_TOKENIZER)
+    explainer = DummyExplainer(DISTILBERT_MODEL, DISTILBERT_TOKENIZER)
     s = "DummyExplainer("
-    s += f'\n\ttext="{test_string[:10]}...",'
     s += f"\n\tmodel={DISTILBERT_MODEL.__class__.__name__},"
     s += f"\n\ttokenizer={DISTILBERT_TOKENIZER.__class__.__name__}"
     s += ")"

--- a/test/test_sequence_classification_explainer.py
+++ b/test/test_sequence_classification_explainer.py
@@ -69,9 +69,9 @@ def test_sequence_classification_explainer_attribution_type_unset_before_run():
     assert seq_explainer.attribution_type == "lig"
     assert seq_explainer.attributions == None
     seq_explainer.attribution_type = "UNSUPPORTED"
-    attr = seq_explainer(explainer_string)
-    assert attr == None
-    assert seq_explainer.attributions == None
+    with pytest.raises(ValueError):
+        seq_explainer(explainer_string)
+        assert seq_explainer.attributions == None
 
 
 def test_sequence_classification_encode():
@@ -103,10 +103,10 @@ def test_sequence_classification_run_text_given():
     seq_explainer = SequenceClassificationExplainer(
         DISTILBERT_MODEL, DISTILBERT_TOKENIZER
     )
-    attributions = seq_explainer._run("I love you, I just love you")
-    assert isinstance(attributions, LIGAttributions)
+    word_attributions = seq_explainer._run("I love you, I just love you")
+    assert isinstance(word_attributions, list)
 
-    actual_tokens = [token for token, _ in attributions.word_attributions]
+    actual_tokens = [token for token, _ in word_attributions]
     expected_tokens = [
         "[CLS]",
         "i",
@@ -127,7 +127,7 @@ def test_sequence_classification_explain_on_cls_index():
     seq_explainer = SequenceClassificationExplainer(
         DISTILBERT_MODEL, DISTILBERT_TOKENIZER
     )
-    attributions = seq_explainer._run(explainer_string, index=0)
+    word_attributions = seq_explainer._run(explainer_string, index=0)
     assert seq_explainer.predicted_class_index == 1
     assert seq_explainer.predicted_class_index != seq_explainer.selected_index
     assert (
@@ -144,7 +144,7 @@ def test_sequence_classification_explain_position_embeddings():
     pos_attributions = seq_explainer(explainer_string, embedding_type=1)
     word_attributions = seq_explainer(explainer_string, embedding_type=0)
 
-    assert pos_attributions.word_attributions != word_attributions.word_attributions
+    assert pos_attributions != word_attributions
 
 
 def test_sequence_classification_explain_position_embeddings_not_available():
@@ -155,7 +155,7 @@ def test_sequence_classification_explain_position_embeddings_not_available():
     pos_attributions = seq_explainer(explainer_string, embedding_type=1)
     word_attributions = seq_explainer(explainer_string, embedding_type=0)
 
-    assert pos_attributions.word_attributions == word_attributions.word_attributions
+    assert pos_attributions == word_attributions
 
 
 def test_sequence_classification_explain_embedding_incorrect_value():
@@ -165,11 +165,11 @@ def test_sequence_classification_explain_embedding_incorrect_value():
     )
 
     word_attributions = seq_explainer(explainer_string, embedding_type=0)
-    incorrect_value_attributions = seq_explainer(explainer_string, embedding_type=-42)
+    incorrect_word_attributions = seq_explainer(explainer_string, embedding_type=-42)
 
     assert (
-        incorrect_value_attributions.word_attributions
-        == word_attributions.word_attributions
+        incorrect_word_attributions
+        == word_attributions
     )
 
 

--- a/test/test_sequence_classification_explainer.py
+++ b/test/test_sequence_classification_explainer.py
@@ -217,6 +217,26 @@ def test_sequence_classification_explain_raises_on_input_ids_not_calculated():
         seq_explainer.predicted_class_index
 
 
+def test_sequence_classification_word_attributions():
+    explainer_string = "I love you , I like you"
+    seq_explainer = SequenceClassificationExplainer(
+        DISTILBERT_MODEL, DISTILBERT_TOKENIZER
+    )
+    seq_explainer(explainer_string)
+    assert isinstance(seq_explainer.word_attributions, list)
+    for element in seq_explainer.word_attributions:
+        assert isinstance(element, tuple)
+
+
+def test_sequence_classification_word_attributions_not_calculated_raises():
+    explainer_string = "I love you , I like you"
+    seq_explainer = SequenceClassificationExplainer(
+        DISTILBERT_MODEL, DISTILBERT_TOKENIZER
+    )
+    with pytest.raises(ValueError):
+        seq_explainer.word_attributions
+
+
 def test_sequence_classification_explainer_str():
     seq_explainer = SequenceClassificationExplainer(
         DISTILBERT_MODEL, DISTILBERT_TOKENIZER

--- a/transformers_interpret/attributions.py
+++ b/transformers_interpret/attributions.py
@@ -77,7 +77,7 @@ class LIGAttributions(Attributions):
             )
 
     @property
-    def word_attributions(self):
+    def word_attributions(self) -> list:
         wa = []
         if len(self.attributions_sum) >= 1:
             for i, (word, attribution) in enumerate(

--- a/transformers_interpret/explainer.py
+++ b/transformers_interpret/explainer.py
@@ -74,7 +74,7 @@ class BaseExplainer(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _run(self):  # Add abstract type return for attribution
+    def _run(self) -> list:
         raise NotImplementedError
 
     @abstractmethod

--- a/transformers_interpret/explainer.py
+++ b/transformers_interpret/explainer.py
@@ -10,12 +10,10 @@ from transformers import PreTrainedModel, PreTrainedTokenizer
 
 class BaseExplainer(ABC):
     def __init__(
-        self, text: str, model: PreTrainedModel, tokenizer: PreTrainedTokenizer
+        self, model: PreTrainedModel, tokenizer: PreTrainedTokenizer
     ):
         self.model = model
         self.tokenizer = tokenizer
-        text = self._clean_text(text)
-        self.text = text
 
         if self.model.config.model_type == "gpt2":
             self.ref_token_id = self.tokenizer.eos_token_id
@@ -204,7 +202,6 @@ class BaseExplainer(ABC):
 
     def __str__(self):
         s = f"{self.__class__.__name__}("
-        s += f'\n\ttext="{str(self.text[:10])}...",'
         s += f"\n\tmodel={self.model.__class__.__name__},"
         s += f"\n\ttokenizer={self.tokenizer.__class__.__name__}"
         s += ")"

--- a/transformers_interpret/explainer.py
+++ b/transformers_interpret/explainer.py
@@ -1,7 +1,7 @@
 import abc
 import inspect
 import re
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
 from typing import List, Tuple, Union
 
 import torch
@@ -9,9 +9,7 @@ from transformers import PreTrainedModel, PreTrainedTokenizer
 
 
 class BaseExplainer(ABC):
-    def __init__(
-        self, model: PreTrainedModel, tokenizer: PreTrainedTokenizer
-    ):
+    def __init__(self, model: PreTrainedModel, tokenizer: PreTrainedTokenizer):
         self.model = model
         self.tokenizer = tokenizer
 
@@ -69,6 +67,10 @@ class BaseExplainer(ABC):
             word tokens for a sentence/document.
 
         """
+        raise NotImplementedError
+
+    @abstractproperty
+    def word_attributions(self):
         raise NotImplementedError
 
     @abstractmethod

--- a/transformers_interpret/explainers/sequence_classification.py
+++ b/transformers_interpret/explainers/sequence_classification.py
@@ -183,8 +183,6 @@ class SequenceClassificationExplainer(BaseExplainer):
             )
             lig.summarize()
             self.attributions = lig
-        else:
-            pass
 
     def _run(
         self,
@@ -214,7 +212,7 @@ class SequenceClassificationExplainer(BaseExplainer):
         self._calculate_attributions(
             embeddings=embeddings, index=index, class_name=class_name
         )
-        return self.attributions  # type: ignore
+        return self.word_attributions  # type: ignore
 
     def __call__(
         self,
@@ -222,7 +220,7 @@ class SequenceClassificationExplainer(BaseExplainer):
         index: int = None,
         class_name: str = None,
         embedding_type: int = 0,
-    ) -> LIGAttributions:
+    ) -> list:
         """
         Calculates attribution for `text` using the model
         and tokenizer given in the constructor.

--- a/transformers_interpret/explainers/sequence_classification.py
+++ b/transformers_interpret/explainers/sequence_classification.py
@@ -190,7 +190,7 @@ class SequenceClassificationExplainer(BaseExplainer):
         index: int = None,
         class_name: str = None,
         embedding_type: int = None,
-    ) -> LIGAttributions:  # type: ignore
+    ) -> list:  # type: ignore
         if embedding_type is None:
             embeddings = self.word_embeddings
         else:
@@ -242,7 +242,7 @@ class SequenceClassificationExplainer(BaseExplainer):
             embedding_type (int, optional): The embedding type word(0) or position(1) to calculate attributions for. Defaults to 0.
 
         Returns:
-            LIGAttributions:
+            list: List of tuples containing words and their associated attribution scores. 
         """
         return self._run(text, index, class_name, embedding_type=embedding_type)
 


### PR DESCRIPTION
Introduces some major breaking changes to the interface. 
- Text is no longer passed in the constructor and is now exclusively passed to the instance only when calculating attributions. 
- Rather than returning the LIGAttributions instance we now return `word_attributions` by default when calling the explainer. `word_attributions` are now also an accessible property of the classification explainer. 