### PR TITLE
Use model.device instead of moving the model on initialization

### DIFF
--- a/test/test_explainer.py
+++ b/test/test_explainer.py
@@ -52,10 +52,7 @@ def test_explainer_init_distilbert():
         explainer.tokenizer, PreTrainedTokenizer
     )
     assert explainer.model_prefix == DISTILBERT_MODEL.base_model_prefix
-    if torch.cuda.is_available():
-        assert explainer.device.type == "cuda:0"
-    else:
-        assert explainer.device.type == "cpu"
+    assert explainer.device == DISTILBERT_MODEL.device
 
     assert explainer.accepts_position_ids is False
     assert explainer.accepts_token_type_ids is False
@@ -73,10 +70,7 @@ def test_explainer_init_bert():
         explainer.tokenizer, PreTrainedTokenizer
     )
     assert explainer.model_prefix == BERT_MODEL.base_model_prefix
-    if torch.cuda.is_available():
-        assert explainer.device.type == "cuda:0"
-    else:
-        assert explainer.device.type == "cpu"
+    assert explainer.device == BERT_MODEL.device
 
     assert explainer.accepts_position_ids is True
     assert explainer.accepts_token_type_ids is True
@@ -94,10 +88,7 @@ def test_explainer_init_gpt2():
         explainer.tokenizer, PreTrainedTokenizer
     )
     assert explainer.model_prefix == GPT2_MODEL.base_model_prefix
-    if torch.cuda.is_available():
-        assert explainer.device.type == "cuda:0"
-    else:
-        assert explainer.device.type == "cpu"
+    assert explainer.device == GPT2_MODEL.device
 
     assert explainer.accepts_position_ids is True
     assert explainer.accepts_token_type_ids is True

--- a/test/test_explainer.py
+++ b/test/test_explainer.py
@@ -108,6 +108,19 @@ def test_explainer_init_cpu():
         DISTILBERT_MODEL.to(old_device)
 
 
+def test_explainer_init_cuda():
+    if not torch.cuda.is_available():
+        print("Cuda device not available to test. Skipping.")
+    else:
+        old_device = DISTILBERT_MODEL.device
+        try:
+            DISTILBERT_MODEL.to("cuda")
+            explainer = DummyExplainer(DISTILBERT_MODEL, DISTILBERT_TOKENIZER)
+            assert explainer.device.type == "cuda"
+        finally:
+            DISTILBERT_MODEL.to(old_device)
+
+
 def test_explainer_make_input_reference_pair():
     explainer = DummyExplainer(DISTILBERT_MODEL, DISTILBERT_TOKENIZER)
     input_ids, ref_input_ids, len_inputs = explainer._make_input_reference_pair(

--- a/test/test_explainer.py
+++ b/test/test_explainer.py
@@ -98,6 +98,16 @@ def test_explainer_init_gpt2():
     assert explainer.word_embeddings is not None
 
 
+def test_explainer_init_cpu():
+    old_device = DISTILBERT_MODEL.device
+    try:
+        DISTILBERT_MODEL.to("cpu")
+        explainer = DummyExplainer(DISTILBERT_MODEL, DISTILBERT_TOKENIZER)
+        assert explainer.device.type == "cpu"
+    finally:
+        DISTILBERT_MODEL.to(old_device)
+
+
 def test_explainer_make_input_reference_pair():
     explainer = DummyExplainer(DISTILBERT_MODEL, DISTILBERT_TOKENIZER)
     input_ids, ref_input_ids, len_inputs = explainer._make_input_reference_pair(

--- a/transformers_interpret/explainer.py
+++ b/transformers_interpret/explainer.py
@@ -44,8 +44,7 @@ class BaseExplainer(ABC):
         else:
             self.accepts_token_type_ids = False
 
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        self.model.to(self.device)
+        self.device = self.model.device
 
         self.word_embeddings = self.model.get_input_embeddings()
         self.position_embeddings = None


### PR DESCRIPTION
# PR Description

This PR prevents Explainer initialization from changing the model device. This fixes some simple and common use cases which otherwise produce errors. The Explainer can work with the `model.device` property instead.

## Motivation and Context

Instead of guessing which device to use, stick to the model's device property. This property has been available since transformers 2.7.0 (which is older than the current required version). Without it, the user is forced to run the models on GPU (if available, not always preferred) and some common use cases produce errors.

Here is an example of a simple case that previously produces an error - as the model's device is changed by the Explainer:
```
import transformers
import transformers_interpret
classifier = transformers.pipeline("zero-shot-classification")
explainer = transformers_interpret.ZeroShotClassificationExplainer(classifier.model, classifier.tokenizer)
print(explainer("bluebear", ["animal", "art", "fruit"]))
print(classifier("bluebear", ["animal", "art", "fruit"]))
```

Yielding:
```   1850         # remove once script supports set_grad_enabled
   1851         _no_grad_embedding_renorm_(weight, input, max_norm, norm_type)
-> 1852     return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)

RuntimeError: Input, output and indices must be on the current device
```

Note: Perhaps `explainer.device` should be dropped entirely in favor of using `model.device` dynamically.

## Tests and Coverage

Existing asserts have been updated to check that explainers use the models' devices. (Incidentally, these tests were also failing in a fresh checkout - device.type "cuda" instead of "cuda:0")

Two new tests have been added which initialize explainers on cpu and cuda respectively.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Docs (Added to or improved  Transformers Interpret's documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Final Checklist:

- [x] My code follows the [code style](https://github.com/cdpierse/transformers-interpret/blob/master/CONTRIBUTING.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.