### PR TITLE
Fix path for Pairwise Sequence Classification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,12 @@ Before you submit your pull request consider the following guidelines:
 
 - Search [GitHub](https://github.com/cdpierse/transformers-interpret/pulls) for an open or closed Pull Request
   that relates to your submission. You don't want to duplicate effort.
+- Create a fork of a repository and set up a remote that points to the original project: 
+
+  ```shell
+  git remote add upstream git@github.com:cdpierse/transformers-interpret.git
+  ```
+
 - Make your changes in a new git branch, based off master branch:
 
   ```shell

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ For this example we are using `"cross-encoder/ms-marco-MiniLM-L-6-v2"`, a high q
 ```python
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
-from transformers_interpret.explainers.sequence_classification import PairwiseSequenceClassificationExplainer
+from transformers_interpret import PairwiseSequenceClassificationExplainer
 
 model = AutoModelForSequenceClassification.from_pretrained("cross-encoder/ms-marco-MiniLM-L-6-v2")
 tokenizer = AutoTokenizer.from_pretrained("cross-encoder/ms-marco-MiniLM-L-6-v2")


### PR DESCRIPTION
# PR Description

Hey! It's a tiny PR about fixing the path to PairwiseSequenceClassificationExplainer in README.md. Currently it's 

`from transformers_interpret.explainers.sequence_classification import PairwiseSequenceClassificationExplainer`

Should be either `from transformers_interpret.explainers.text.sequence_classification import PairwiseSequenceClassificationExplainer` or just `from transformers_interpret import PairwiseSequenceClassificationExplainer`. The latter is more universal, so I fixed it 

Also added a couple of lines in CONTRIBUTION.md about needing to fork the repo in order to create a PR. Maybe it's self-evident, but I definitely tried pushing directly at first :D So maybe it'll help someone in the future 


## Motivation and Context

The path `from transformers_interpret.explainers.sequence_classification import PairwiseSequenceClassificationExplainer` is broken 

## Tests and Coverage

I assume there are no tests for docs ¯\_(ツ)_/¯

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Docs (Added to or improved  Transformers Interpret's documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Final Checklist:

- [x] My code follows the [code style](https://github.com/cdpierse/transformers-interpret/blob/master/CONTRIBUTING.md) of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
