### PR TITLE
Make MultiLabelClassificationExplainer use sigmoid activation, added MultiClassClassificationExplainer, labels sorted according to label id

### DIFF
--- a/transformers_interpret/__init__.py
+++ b/transformers_interpret/__init__.py
@@ -6,6 +6,9 @@ from .explainers.text.sequence_classification import (
     PairwiseSequenceClassificationExplainer,
 )
 from .explainers.text.zero_shot_classification import ZeroShotClassificationExplainer
-from .explainers.text.multilabel_classification import MultiLabelClassificationExplainer
+from .explainers.text.multilabel_classification import (
+    MultiLabelClassificationExplainer,
+    MultiClassClassificationExplainer
+)
 from .explainers.text.token_classification import TokenClassificationExplainer
 from .explainers.vision.image_classification import ImageClassificationExplainer

--- a/transformers_interpret/explainers/text/__init__.py
+++ b/transformers_interpret/explainers/text/__init__.py
@@ -1,4 +1,4 @@
-from .multilabel_classification import MultiLabelClassificationExplainer
+from .multilabel_classification import MultiLabelClassificationExplainer, MultiClassClassificationExplainer
 from .question_answering import QuestionAnsweringExplainer
 from .sequence_classification import SequenceClassificationExplainer, PairwiseSequenceClassificationExplainer
 from .zero_shot_classification import ZeroShotClassificationExplainer

--- a/transformers_interpret/explainers/text/multilabel_classification.py
+++ b/transformers_interpret/explainers/text/multilabel_classification.py
@@ -127,7 +127,7 @@ class MultiLabelClassificationExplainer(SequenceClassificationExplainer):
 
         self.attributions = []
         self.pred_probs = []
-        self.labels = list(self.label2id.keys())
+        self.labels = [item[0] for item in sorted(self.label2id.items(), key=lambda x: x[1])]
         self.label_probs_dict = {}
         for i in range(self.model.config.num_labels):
             explainer = SequenceClassificationExplainer(

--- a/transformers_interpret/explainers/text/sequence_classification.py
+++ b/transformers_interpret/explainers/text/sequence_classification.py
@@ -183,8 +183,10 @@ class SequenceClassificationExplainer(BaseExplainer):
             self.pred_probs = torch.sigmoid(preds)[0][0]
             return torch.sigmoid(preds)[:, :]
 
-        self.pred_probs = torch.softmax(preds, dim=1)[0][self.selected_index]
-        return torch.softmax(preds, dim=1)[:, self.selected_index]
+        self.pred_probs = torch.sigmoid(preds)[0][self.selected_index]
+        return torch.sigmoid(preds)[:, self.selected_index]
+        #self.pred_probs = torch.softmax(preds, dim=1)[0][self.selected_index]
+        #return            torch.softmax(preds, dim=1)[:, self.selected_index]
 
     def _calculate_attributions(self, embeddings: Embedding, index: int = None, class_name: str = None):  # type: ignore
         (


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the Title above -->

Changed activation function applied to output logits in class `MultiLabelClassificationExplainer`. Is now using sigmoid.
Added a class `MultiClassClassificationExplainer` that uses softmax on output logits like `MultiLabelClassificationExplainer` used to do.

Sorting of labels is done according to the label index instead of default sorting.

<!--- Describe the changes your PR makes in detail -->


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
the multi-label class `MultiLabelClassificationExplainer` should be implemented with sigmoid instead of softmax on the output.

To keep the multi-class functionality, a new class `MultiClassClassificationExplainer` is created. 
(which might cause issues/confusion for existing users)

I also made a minor change to the ordering of labels (as i think theres a bug with these too). I believe the ordering of the labels should follow the ids in the label2id dict. without sorting based on the id, the labels are swapped in the output html file generated with the visualize() function
References issue: #107

## Tests and Coverage

Instantiated and vizualised `MultiLabelClassificationExplainer` and `MultiClassClassificationExplainer` and verified HTML output.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Docs (Added to or improved  Transformers Interpret's documentation)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Final Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the [code style](https://github.com/cdpierse/transformers-interpret/blob/master/CONTRIBUTING.md) of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
